### PR TITLE
fix grub boot entry

### DIFF
--- a/app/resources.py
+++ b/app/resources.py
@@ -13,12 +13,12 @@ custom_template = """
 menuentry '{osname}' {{ # {pid} - ax86-installer
 insmod all_video # {pid} - ax86-installer
 search --set=root --file /{name}/findme # {pid} - ax86-installer
-linux /{name}/kernel quiet root=/dev/ram0 androidboot.selinux=permissive SRC=/{osname}/ noibrs noibpb nopti nospectre_v2 nospectre_v1 l1tf=off nospec_store_bypass_disable no_stf_barrier mds=off intel_pstate=disable mitigations=off # {pid} - ax86-installer
+linux /{name}/kernel root=/dev/ram0 acpi_osi=Linux mitigations=off androidboot.hardware=android_x86_64 androidboot.selinux=permissive SRC=/{osname}/ # {pid} - ax86-installer
 initrd /{name}/initrd.img # {pid} - ax86-installer
 }} # {pid} - ax86-installer
 """
 
 custom_entry = """insmod all_video
 search --set=root --file /{name}/findme
-linux /{name}/kernel quiet root=/dev/ram0 androidboot.selinux=permissive SRC=/{osname}/ noibrs noibpb nopti nospectre_v2 nospectre_v1 l1tf=off nospec_store_bypass_disable no_stf_barrier mds=off intel_pstate=disable mitigations=off
+linux /{name}/kernel root=/dev/ram0 acpi_osi=Linux mitigations=off androidboot.hardware=android_x86_64 androidboot.selinux=permissive SRC=/{osname}/
 initrd /{name}/initrd.img"""


### PR DESCRIPTION
androidboot.hardware=android_x86_64  is required by android x86.
and acpi_osi=Linux is to avoid ACPI errors on some laptops.
mitigations=off is enough to disable all the mitigations. 
disabling intel_pstate is not a good idea can cause kernel panic in some Devices.